### PR TITLE
Add support for local path type packages

### DIFF
--- a/res/composer-project.nix.php
+++ b/res/composer-project.nix.php
@@ -57,6 +57,8 @@ in stdenv.mkDerivation {
 
     # Build the cache directory contents.
     source ${collectCacheScript}
+
+    # Replace local package paths with their Nix store equivalent.
     source ${replaceLocalPaths}
 
     # Store the absolute path to Composer for the 'composer' alias.

--- a/res/composer-project.nix.php
+++ b/res/composer-project.nix.php
@@ -14,6 +14,7 @@ let
 
   composerPath = <?php echo $composerPath; ?>;
   cacheEntries = <?php echo $cacheEntries; ?>;
+  localPackages = <?php echo $localPackages; ?>;
 
   # Shell snippet to collect all project dependencies.
   collectCacheScript = writeText "collect-cache.sh" (
@@ -25,6 +26,12 @@ let
         cp ${escapeShellArg (fetcher args)} "$cacheFilePath"
       )
     '') cacheEntries
+  );
+
+  replaceLocalPaths = writeText "replace-local-paths.sh" (
+    concatMapStrings (args: ''
+      sed -i -e "s|\"${args.string}\"|\"${args.path}\"|" composer.lock
+    '') localPackages
   );
 
 in stdenv.mkDerivation {
@@ -50,6 +57,7 @@ in stdenv.mkDerivation {
 
     # Build the cache directory contents.
     source ${collectCacheScript}
+    source ${replaceLocalPaths}
 
     # Store the absolute path to Composer for the 'composer' alias.
     export NIX_COMPOSER_PATH="$(readlink -f ${escapeShellArg composerPath})"


### PR DESCRIPTION
This PR adds support for packages installed from [path repositories](https://getcomposer.org/doc/05-repositories.md#path).

I'm not strong on the details of Nix store, etc, so I don't know if this the right approach, but it seems to be working for me in our monorepo.

![image](https://user-images.githubusercontent.com/2466322/132058494-b237b8da-5b18-4057-9a13-d2ff0a8e71b1.png)

Let me know if you want me to make any adjustments.